### PR TITLE
fix(ldap): allow the connection pool to init

### DIFF
--- a/Authenticator/src/Authy/IDStores/LDAP.pm
+++ b/Authenticator/src/Authy/IDStores/LDAP.pm
@@ -114,7 +114,7 @@ sub initialize {
             RetryDelay => [$connection_retry_delay],
         );
     };
-    die "Could not initialize LDAP connection pool: $@\n";
+    die "Could not initialize LDAP connection pool: $@\n" if $@;
 }
 
 sub _get_value {


### PR DESCRIPTION
Hi,

This PR corrects a bug where the LDAP connection pool does not init, because the module crashes with no condition.

Thank you 👍

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
