### PR TITLE
fix(main): use JSON allow_nonref

### DIFF
--- a/Authenticator/src/Authy/AuthyAuthenticator.pl
+++ b/Authenticator/src/Authy/AuthyAuthenticator.pl
@@ -9,7 +9,7 @@ use Authy::Text;
 use Carp qw(croak);
 use HTTP::Headers;
 use HTTP::Status qw(:constants);
-use JSON qw(encode_json decode_json);
+use JSON;
 use LWP::UserAgent;
 use Module::Load qw(load);
 use Time::HiRes qw(time sleep);
@@ -352,7 +352,7 @@ sub _send_otp_request {
     # Convert the response content to JSON.
     my $res_code = $res->code();
     my $res_content = $res->decoded_content();
-    my $res_json = eval { decode_json($res_content) };
+    my $res_json = eval { JSON->new->allow_nonref->decode($res_content) };
     die err(ERR_OTP_PROMPT_REQUEST_FAILED_EXTERNALLY, $res_code, $@)."\n" if $@;
 
     # Process the response.
@@ -384,7 +384,7 @@ sub _is_correct_otp {
     # Convert the response content to JSON.
     my $res_code = $res->code();
     my $res_content = $res->decoded_content();
-    my $res_json = eval { decode_json($res_content) };
+    my $res_json = eval { JSON->new->allow_nonref->decode($res_content) };
     die err(ERR_OTP_VERIFICATION_REQUEST_FAILED_EXTERNALLY, $res_code, $@)."\n" if $@;
 
     # The token is valid if the response was 200 OK and the token "is valid".
@@ -426,7 +426,7 @@ sub _create_one_touch_approval_request {
     };
     my $res = $user_agent->post(cfg_one_touch_approval_request_creation_url($id),
         Content_Type => 'application/json',
-        Content => encode_json($data)
+        Content => JSON->new->allow_nonref->encode($data)
     );
     eval {
         _ensure_external_response($res);
@@ -436,7 +436,7 @@ sub _create_one_touch_approval_request {
     # Convert the response content to JSON.
     my $res_code = $res->code();
     my $res_content = $res->decoded_content();
-    my $res_json = eval { decode_json($res_content) };
+    my $res_json = eval { JSON->new->allow_nonref->decode($res_content) };
     die err(ERR_ONE_TOUCH_APPROVAL_REQUEST_CREATION_FAILED_EXTERNALLY, $res_code, $@)."\n" if $@;
 
     # Return the request UUID sent back from Authy if provided.
@@ -510,7 +510,7 @@ sub _parse_one_touch_api_endpoint_response {
     # Convert the response content to JSON.
     my $res_code = $res->code();
     my $res_content = $res->decoded_content();
-    my $res_json = eval { decode_json($res_content) };
+    my $res_json = eval { JSON->new->allow_nonref->decode($res_content) };
     die err(ERR_ONE_TOUCH_APPROVAL_REQUEST_CREATION_FAILED_EXTERNALLY, $res_code, $@)."\n" if $@;
 
     # Extract the response details.


### PR DESCRIPTION
Hi,

I face the following error message with `encode_json` and `decode_json` functions :
`JSON text must be an object or array (but found number, string, true, false or null, use allow_nonref to allow this)`
Which then makes the whole Twilio FreeRADIUS MFA plugin to fail.

This PR then corrects this using `allow_nonref` as proposed in the error message, and [manual](https://metacpan.org/pod/JSON#allow_nonref).

Thank you :+1:

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
