### PR TITLE
fix(main): allow smartmatch

### DIFF
--- a/Authenticator/src/Authy/AuthyState.pm
+++ b/Authenticator/src/Authy/AuthyState.pm
@@ -5,6 +5,8 @@ use strict;
 use warnings FATAL => 'all';
 use overload '""' => \&stringify;
 
+use experimental 'smartmatch';
+
 use Authy::Configuration;
 use Authy::Text;
 use Carp qw(croak);


### PR DESCRIPTION
Hi,

This PR corrects the following error message :
`Smartmatch is experimental at Authy/AuthyState.pm line 50.`
Which then makes the whole module to crash.

Thank you 👍 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
