### PR TITLE
fix(main): toggle cfg_otp_allow_unregistered_users

### DIFF
--- a/Authenticator/src/Authy/Configuration.pm
+++ b/Authenticator/src/Authy/Configuration.pm
@@ -607,7 +607,7 @@ sub cfg_otp_verification_url {
     my ($otp, $id) = @_;
     croak "No OTP specified" unless defined $otp;
     croak "No ID specified" unless defined $id;
-    return sprintf _AUTHY_OTP_VERIFICATION_URL, $otp, $id, (cfg_otp_allow_unregistered_users() ? 'false' : 'true');
+    return sprintf _AUTHY_OTP_VERIFICATION_URL, $otp, $id, (cfg_otp_allow_unregistered_users() ? 'true' : 'false');
 }
 
 sub cfg_one_touch_approval_request_creation_url {


### PR DESCRIPTION
Hi,

This PR fixes an issue where `cfg_otp_allow_unregistered_users` if not used in the right order.

Thx 👍 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
