### PR TITLE
enh(main): add an option to automatically create users

### DIFF
--- a/Authenticator/src/Authy/Text.pm
+++ b/Authenticator/src/Authy/Text.pm
@@ -39,6 +39,10 @@ our @EXPORT = qw(
     ERR_AUTH_ID_RETRIEVAL_FAILED
     ERR_AUTH_INVALID_ID
     ERR_AUTH_INVALID_STATE
+    ERR_AUTH_NO_EMAIL_IN_REQUEST
+    ERR_AUTH_NO_CELLPHONE_IN_REQUEST
+    ERR_AUTH_NO_COUNTRYCODE_IN_REQUEST
+    ERR_AUTH_ID_SAVING_FAILED
 
     ERR_OTP_PROMPT_REQUEST_FAILED_INTERNALLY
     ERR_OTP_PROMPT_REQUEST_FAILED_EXTERNALLY
@@ -52,6 +56,9 @@ our @EXPORT = qw(
     ERR_ONE_TOUCH_CUSTOM_ENDPOINT_FAILED_INTERNALLY
     ERR_ONE_TOUCH_CUSTOM_ENDPOINT_FAILED_EXTERNALLY
     ERR_ONE_TOUCH_ENDPOINT_RETURNED_INVALID_STATUS
+
+    ERR_CREATE_USER_REQUEST_FAILED_INTERNALLY
+    ERR_CREATE_USER_REQUEST_FAILED_EXTERNALLY
 
     msg
     err
@@ -88,6 +95,10 @@ use constant {
     ERR_AUTH_ID_RETRIEVAL_FAILED                              => '01-007',
     ERR_AUTH_INVALID_ID                                       => '01-008',
     ERR_AUTH_INVALID_STATE                                    => '01-009',
+    ERR_AUTH_NO_EMAIL_IN_REQUEST                              => '01-010',
+    ERR_AUTH_NO_CELLPHONE_IN_REQUEST                          => '01-011',
+    ERR_AUTH_NO_COUNTRYCODE_IN_REQUEST                        => '01-012',
+    ERR_AUTH_ID_SAVING_FAILED                                 => '01-013',
 
     ERR_OTP_PROMPT_REQUEST_FAILED_INTERNALLY                  => '02-001',
     ERR_OTP_PROMPT_REQUEST_FAILED_EXTERNALLY                  => '02-002',
@@ -101,6 +112,9 @@ use constant {
     ERR_ONE_TOUCH_CUSTOM_ENDPOINT_FAILED_INTERNALLY           => '03-005',
     ERR_ONE_TOUCH_CUSTOM_ENDPOINT_FAILED_EXTERNALLY           => '03-006',
     ERR_ONE_TOUCH_ENDPOINT_RETURNED_INVALID_STATUS            => '03-007',
+
+    ERR_CREATE_USER_REQUEST_FAILED_INTERNALLY                 => '04-001',
+    ERR_CREATE_USER_REQUEST_FAILED_EXTERNALLY                 => '04-002',
 };
 
 our %_MESSAGES = ();
@@ -132,6 +146,14 @@ our %_ERRORS = (
         "Invalid Authy ID",
     ERR_AUTH_INVALID_STATE() =>
         "Invalid Authy state: %s",
+    ERR_AUTH_NO_EMAIL_IN_REQUEST() =>
+        "No email found in the request",
+    ERR_AUTH_NO_CELLPHONE_IN_REQUEST() =>
+        "No cellphone found in the request",
+    ERR_AUTH_NO_COUNTRYCODE_IN_REQUEST() =>
+        "No country code found in the request",
+    ERR_AUTH_ID_SAVING_FAILED() =>
+        "ID saving failed: %s",
 
     ERR_OTP_PROMPT_REQUEST_FAILED_INTERNALLY() =>
         "Could not send Authy OTP prompt request: %s",
@@ -156,6 +178,11 @@ our %_ERRORS = (
         "Authy OneTouch custom endpoint poll failed with status code %s: %s",
     ERR_ONE_TOUCH_ENDPOINT_RETURNED_INVALID_STATUS() =>
         "Authy OneTouch custom endpoint returned an invalid status: '%s'",
+
+    ERR_CREATE_USER_REQUEST_FAILED_INTERNALLY() =>
+        "Could not send Authy create user request: %s",
+    ERR_CREATE_USER_REQUEST_FAILED_EXTERNALLY() =>
+        "Authy create user request failed with status code %s: %s",
 );
 
 sub import {

--- a/Authenticator/src/config.ini
+++ b/Authenticator/src/config.ini
@@ -13,6 +13,7 @@ OTPEnabled = yes
 OneTouchEnabled = yes
 OTPOption = 1
 OneTouchOption = 2
+CreateUser = no
 #IDStoreHome = /tmp/id-store
 IDStoreModule = Authy::IDStores::CSV
 


### PR DESCRIPTION
Hi,

This PR adds a new configuration option : `CreateUser`.
If set to `yes`, Authy users will automatically be created if they do not exist in the Authy account yet.
So, when a user first tries to authenticate through the Radius server, his Authy account will automatically be created, so that he'll be able to flawlessy / successfully authenticate.
It's then no more needed for the administrator of the authentication solution to manually add every new user...

Here's one of the situation where this is really useful :

Think about a Radius server newly connected to an existing enterprise directory containing thousands of users.
The Radius server runs this `authy-freeradius` module to double-authenticate the users.
The Radius configuration even enforces it, so that users must succeed with 2FA, thus increasing authentication security of the company's employees.
As a result, a user can't login to the VPN of the company if he does not succeed with 2FA.

The administrator of this authentication solution will then find really helpful for the users to automatically be added into the enterprise Authy account when they authenticate for the first time, instead of having to add each one of them manually.
There's no reason to go with a manual process here, which would furthermore be painful with large user directories...

This is exactly why this `CreateUser` option has been added.
Of course, as it is an option, it can be enabled, or not.
And as FreeRadius is highly configurable, `authy-freeradius` module itself can be used on a per user basis, per group basis or whatever, depending on other things such as user-properties from the enterprise directory etc...
What is important here is that if the authenticating user goes through the `authy-freeradius` module, his Authy user is automatically created, thanks to the `CreateUser` option.

Note that I use this PR since months, without any problem.

Thank you 👍

Note that the 2 PDF documentations (Release Notes and Installation Guide) could perhaps be updated accordingly.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.